### PR TITLE
App path config

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "package-linux": "pkg . -o dist/ad4m-linux-x64 -t node16-linux-x64 --public-packages \"*\"",
     "package-windows": "pkg . -o dist/ad4m-windows-x64 -t node16-windows-x64 --public-packages \"*\"",
     "release-macos": "npm run build && npm run package-macos",
-    "dev": "npm run build && node build/cli.js",
+    "dev": "npx ts-node src/cli.ts serve",
     "postinstall": "rm -rf node_modules/ipfs-core-types/src"
   },
   "pkg": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "package-linux": "pkg . -o dist/ad4m-linux-x64 -t node16-linux-x64 --public-packages \"*\"",
     "package-windows": "pkg . -o dist/ad4m-windows-x64 -t node16-windows-x64 --public-packages \"*\"",
     "release-macos": "npm run build && npm run package-macos",
-    "dev": "npx ts-node src/cli.ts serve",
+    "dev": "npm run build && node build/cli.js",
     "postinstall": "rm -rf node_modules/ipfs-core-types/src"
   },
   "pkg": {
@@ -43,12 +43,13 @@
   },
   "homepage": "https://github.com/fluxsocial/ad4m-host#readme",
   "dependencies": {
-    "@apollo/client": "^3.3.21",
+    "@apollo/client": "3.4.17",
     "@perspect3vism/ad4m": "^0.1.25",
     "@perspect3vism/ad4m-executor": "^0.1.32",
     "appdata-path": "^1.0.0",
     "esm": "^3.2.25",
     "fs-extra": "^9.1.0",
+    "get-port": "5.1.1",
     "node-wget-js": "^1.0.1",
     "readline-sync": "^1.4.10",
     "unzipper": "^0.10.11",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,8 +57,8 @@ yargs(hideBin(process.argv))
   .strict()
   // Useful aliases.
   .alias({ h: 'help' })
-  .fail((msg, _err) => {
-    console.error('Running command with error: ', msg, _err);
+  .fail((msg, err) => {
+    console.error('Running command with error: ', msg, err);
     process.exit(1);
   })
   .argv;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ yargs(hideBin(process.argv))
   // Useful aliases.
   .alias({ h: 'help' })
   .fail((msg, _err) => {
-    console.error('Running command with error: ', msg);
+    console.error('Running command with error: ', msg, _err);
     process.exit(1);
   })
   .argv;

--- a/src/commands/client/agent.ts
+++ b/src/commands/client/agent.ts
@@ -5,7 +5,10 @@ import { buildAd4mClient, readPassphrase, prettify, CommonOptions } from './util
 export const command: string = 'agent [action]';
 export const desc: string = 'Agent related action';
 
-type Options = CommonOptions;
+type Options = CommonOptions  & {
+  passphrase?: string;
+};
+;
 
 export const builder = (yargs: Argv) =>
   yargs
@@ -14,18 +17,20 @@ export const builder = (yargs: Argv) =>
       describe: 'Action that should be executed on the agent',
       choices: ['generate', 'lock', 'unlock', 'status', 'me'],
       default: 'status',
+    }).options({
+      passphrase: {type: 'string', describe: 'Password for the agent'}
     });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  const { server, verbose, action } = argv;
+  const { server, verbose, action, passphrase } = argv;
   if (verbose) {
     console.info(`Attempting to connect to ${server}`);
   }
   const ad4mClient = buildAd4mClient(server);
   switch (action) {
-    case 'generate': await generate(ad4mClient); break;
+    case 'generate': await generate(ad4mClient, passphrase); break;
     case 'lock': await lock(ad4mClient); break;
-    case 'unlock': await unlock(ad4mClient); break;
+    case 'unlock': await unlock(ad4mClient, passphrase); break;
     case 'status': await status(ad4mClient); break;
     case 'me': await me(ad4mClient); break;
 
@@ -37,8 +42,8 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   process.exit();
 };
 
-async function generate(ad4mClient: Ad4mClient) {
-  const passphrase = readPassphrase();
+async function generate(ad4mClient: Ad4mClient, password: string) {
+  const passphrase = password || readPassphrase();
   const agentStatus = await ad4mClient.agent.generate(passphrase);
   prettify(agentStatus);
 }
@@ -49,8 +54,8 @@ async function lock(ad4mClient: Ad4mClient) {
   prettify(agentStatus);
 }
 
-async function unlock(ad4mClient: Ad4mClient) {
-  const passphrase = readPassphrase();
+async function unlock(ad4mClient: Ad4mClient, password: string) {
+  const passphrase = password || readPassphrase();
   const agentStatus = await ad4mClient.agent.unlock(passphrase);
   prettify(agentStatus);
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -32,7 +32,7 @@ async function copy(source, target) {
 
 type Options = {
   hcOnly?: boolean;
-  relativePath?: string;
+  dataPath?: string;
 };
 
 export const command: string = 'init';
@@ -42,16 +42,16 @@ export const builder = (yargs: Argv) =>
   yargs
     .options({
       hcOnly: { type: "boolean" },
-      relativePath: { 
+      dataPath: { 
         type: 'string', 
-        describe: 'Relative path to the appdata for ad4m-host to store binaries', 
+        describe: 'The relative path for storing ad4m data', 
         alias: 'rp'
       },
     });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  const { hcOnly, relativePath } = argv;
-  const binaryPath = path.join(getAppDataPath(relativePath || 'ad4m'), 'binary')
+  const { hcOnly, dataPath } = argv;
+  const binaryPath = path.join(getAppDataPath(dataPath || 'ad4m'), 'binary')
   
   if(!fs.existsSync(binaryPath)) {
     fs.mkdirSync(binaryPath, { recursive: true })

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,12 +5,12 @@
 import type { Arguments, Argv } from 'yargs';
 import path from 'path';
 import fs from 'fs';
+// @ts-ignore
 import { getAppDataPath } from "appdata-path";
 import utils from 'util';
 
 const copyFile = utils.promisify(fs.copyFile);
 const chmod = utils.promisify(fs.chmod);
-export const binaryPath = path.join(getAppDataPath(), 'ad4m/binary');
 
 async function copy(source, target) {
   //@ts-ignore
@@ -32,6 +32,7 @@ async function copy(source, target) {
 
 type Options = {
   hcOnly?: boolean;
+  relativePath?: string;
 };
 
 export const command: string = 'init';
@@ -40,11 +41,18 @@ export const desc: string = 'Init ad4m service with prebuild binary.';
 export const builder = (yargs: Argv) =>
   yargs
     .options({
-      hcOnly: { type: "boolean" }
+      hcOnly: { type: "boolean" },
+      relativePath: { 
+        type: 'string', 
+        describe: 'Relative path to the appdata for ad4m-host to store binaries', 
+        alias: 'rp'
+      },
     });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  const { hcOnly } = argv;
+  const { hcOnly, relativePath } = argv;
+  const binaryPath = path.join(getAppDataPath(relativePath || 'ad4m-host'), 'binary')
+  
   if(!fs.existsSync(binaryPath)) {
     fs.mkdirSync(binaryPath, { recursive: true })
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -51,7 +51,7 @@ export const builder = (yargs: Argv) =>
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const { hcOnly, relativePath } = argv;
-  const binaryPath = path.join(getAppDataPath(relativePath || 'ad4m-host'), 'binary')
+  const binaryPath = path.join(getAppDataPath(relativePath || 'ad4m'), 'binary')
   
   if(!fs.existsSync(binaryPath)) {
     fs.mkdirSync(binaryPath, { recursive: true })

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -12,7 +12,7 @@ type Options = {
   hcAdminPort?: number;
   hcAppPort?: number;
   connectHolochain?: boolean;
-  relativePath?: string;
+  dataPath?: string;
 };
 
 export const command: string = 'serve';
@@ -39,22 +39,22 @@ export const builder = (yargs: Argv) =>
         type: "boolean", 
         describe: 'Flag to connect existing running holochain process'
       },
-      relativePath: { 
+      dataPath: { 
         type: 'string', 
-        describe: 'Relative path to the appdata for ad4m-host to store binaries', 
+        describe: 'The relative path for storing ad4m data', 
         alias: 'rp'
       },
     });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  const { port, hcAdminPort, hcAppPort, connectHolochain, relativePath } = argv;
+  const { port, hcAdminPort, hcAppPort, connectHolochain, dataPath } = argv;
 
-  const binaryPath = path.join(getAppDataPath(relativePath || 'ad4m'), 'binary');
+  const binaryPath = path.join(getAppDataPath(dataPath || 'ad4m'), 'binary');
 
   const gqlPort = await getPort({ port })
 
   const config = {
-    appDataPath: getAppDataPath(relativePath || ''),
+    appDataPath: getAppDataPath(dataPath || ''),
     resourcePath: binaryPath,
     appDefaultLangPath: path.join(__dirname, "../../temp/languages"),
     ad4mBootstrapLanguages: {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -54,7 +54,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const gqlPort = await getPort({ port })
 
   const config = {
-    appDataPath: getAppDataPath(relativePath || 'ad4m'),
+    appDataPath: getAppDataPath(relativePath || ''),
     resourcePath: binaryPath,
     appDefaultLangPath: path.join(__dirname, "../../temp/languages"),
     ad4mBootstrapLanguages: {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -49,12 +49,12 @@ export const builder = (yargs: Argv) =>
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const { port, hcAdminPort, hcAppPort, connectHolochain, relativePath } = argv;
 
-  const binaryPath = path.join(getAppDataPath(relativePath || 'ad4m-host'), 'binary');
+  const binaryPath = path.join(getAppDataPath(relativePath || 'ad4m'), 'binary');
 
   const gqlPort = await getPort({ port })
 
   const config = {
-    appDataPath: getAppDataPath(relativePath || 'ad4m-host'),
+    appDataPath: getAppDataPath(relativePath || 'ad4m'),
     resourcePath: binaryPath,
     appDefaultLangPath: path.join(__dirname, "../../temp/languages"),
     ad4mBootstrapLanguages: {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,15 +1,18 @@
 import type { Arguments, Argv } from 'yargs';
+// @ts-ignore
 import { init } from "@perspect3vism/ad4m-executor";
 import path from 'path';
 import fs from 'fs';
+// @ts-ignore
 import { getAppDataPath } from "appdata-path";
-import { binaryPath } from './init';
+import getPort from 'get-port';
 
 type Options = {
   port?: number;
   hcAdminPort?: number;
   hcAppPort?: number;
   connectHolochain?: boolean;
+  relativePath?: string;
 };
 
 export const command: string = 'serve';
@@ -18,17 +21,40 @@ export const desc: string = 'Serve ad4m service at given port';
 export const builder = (yargs: Argv) =>
   yargs
     .options({
-      port: { type: 'number', describe: 'Use this port to run ad4m GraphQL service', default: 4000, alias: 'p' },
-      hcAdminPort: { type: 'number', describe: 'Admin port of holochain conductor' },
-      hcAppPort: { type: 'number', describe: 'Port used by hApp' },
-      connectHolochain: { type: "boolean", describe: 'Flag to connect existing running holochain process'}
+      port: { 
+        type: 'number', 
+        describe: 'Use this port to run ad4m GraphQL service', 
+        default: 4000, 
+        alias: 'p'
+      },
+      hcAdminPort: { 
+        type: 'number', 
+        describe: 'Admin port of holochain conductor'
+      },
+      hcAppPort: { 
+        type: 'number', 
+        describe: 'Port used by hApp' 
+      },
+      connectHolochain: { 
+        type: "boolean", 
+        describe: 'Flag to connect existing running holochain process'
+      },
+      relativePath: { 
+        type: 'string', 
+        describe: 'Relative path to the appdata for ad4m-host to store binaries', 
+        alias: 'rp'
+      },
     });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  const { port, hcAdminPort, hcAppPort, connectHolochain } = argv;
+  const { port, hcAdminPort, hcAppPort, connectHolochain, relativePath } = argv;
+
+  const binaryPath = path.join(getAppDataPath(relativePath || 'ad4m-host'), 'binary');
+
+  const gqlPort = await getPort({ port })
 
   const config = {
-    appDataPath: getAppDataPath(),
+    appDataPath: getAppDataPath(relativePath || 'ad4m-host'),
     resourcePath: binaryPath,
     appDefaultLangPath: path.join(__dirname, "../../temp/languages"),
     ad4mBootstrapLanguages: {
@@ -48,7 +74,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     },
     appBuiltInLangs: [],
     mocks: false,
-    gqlPort: port,
+    gqlPort,
     hcPortAdmin: hcAdminPort,
     hcPortApp: hcAppPort,
     connectHolochain,


### PR DESCRIPTION
Adds a way to set custom app location for ad4m-host will be useful to set a custom location for ad4m-test. Adds a new argument for init and serve called `relativePath` or `rp` any name suggestions @kaichaosun @jdeepee 