### PR TITLE
Fixed windows build init command for windows

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,6 +11,7 @@ import utils from 'util';
 import { fetchLatestBootstrapSeed, MAINNET_SEED } from '../utils/fetchLatestBootstrapSeed';
 import { CONFIG, getConfig } from '../utils/config';
 import ReadlineSync from 'readline-sync';
+import os from 'os'
 
 const copyFile = utils.promisify(fs.copyFile);
 const chmod = utils.promisify(fs.chmod);
@@ -71,20 +72,25 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     fs.mkdirSync(binaryPath, { recursive: true })
   }
 
+  const platform = os.platform();
+  const holochain = platform === 'win32' ? 'holochain.exe' : 'holochain';
+  const lair = platform === 'win32' ? 'lair-keystore.exe' : 'lair-keystore';
+  const hc = platform === 'win32' ? 'hc.exe' : 'hc';
+
   if(!hcOnly) {
-    const holochainSource = path.join(__dirname, '../../temp/binary/holochain');
-    const holochaintarget = path.join(binaryPath, 'holochain');
+    const holochainSource = path.join(__dirname, `../../temp/binary/${holochain}`);
+    const holochaintarget = path.join(binaryPath, holochain);
     await copy(holochainSource, holochaintarget);
     await chmod(holochaintarget, '755');
   
-    const lairSource = path.join(__dirname, '../../temp/binary/lair-keystore');
-    const lairTarget = path.join(binaryPath, 'lair-keystore');
+    const lairSource = path.join(__dirname, `../../temp/binary/${lair}`);
+    const lairTarget = path.join(binaryPath, lair);
     await copy(lairSource, lairTarget);
     await chmod(lairTarget, '755');
   }
 
-  const hcSource = path.join(__dirname, '../../temp/binary/hc');
-  const hcTarget = path.join(binaryPath, 'hc');
+  const hcSource = path.join(__dirname, `../../temp/binary/${hc}`);
+  const hcTarget = path.join(binaryPath, hc);
   await copy(hcSource, hcTarget);
   await chmod(hcTarget, '755');
 


### PR DESCRIPTION
Fixes a bug where copying the holochain binaries would result in an error being thrown because of the file name containing .exe.